### PR TITLE
Leave out .then in code examples, use only .done & .fail

### DIFF
--- a/techdocs/api/client/hoodie.md
+++ b/techdocs/api/client/hoodie.md
@@ -74,7 +74,7 @@ todoStore.on('todo:done', function(doneTodo, t) {
   console.log(doneTodo.title, ' was done', t);
 });
 
-todoStore.findAll().then(function(allTodos) {
+todoStore.findAll().done(function(allTodos) {
   // take the first todo in list
   // and mark it as done
   markAsDone(allTodos[0]);
@@ -138,7 +138,7 @@ todoStore.on('todo:done', function(doneTodo, t) {
 // subscribed event handlers
 todoStore.off('todo:done');
 
-todoStore.findAll().then(function(allTodos) {
+todoStore.findAll().done(function(allTodos) {
   todoStore.trigger('todo:done', allTodos[0], new Date());
 });
 ```

--- a/techdocs/api/client/hoodie.store.md
+++ b/techdocs/api/client/hoodie.store.md
@@ -291,7 +291,7 @@ var todoStore = hoodie.store('todo');
 
 todoStore
     .findAll()
-    .then(function(allTodos) {
+    .done(function(allTodos) {
         allTodos.forEach(function(oneTodo) {
             console.log('found', oneTodo);
         });
@@ -314,14 +314,14 @@ console.log(todoStore.findAll());
 
 todoStore
     .findAll()
-    .then(function(allTodos) {
+    .done(function(allTodos) {
         // get an array with all things
         // you have on your todo list
         return allTodos.map(function(todo) {
            return todo.title;
         });
     })
-    .then(function(titles) {
+    .done(function(titles) {
         // print out all the things you have todo
         titles.forEach(function(title) {
             console.log('You have to => ', title);

--- a/techdocs/api/server/hoodie.task.md
+++ b/techdocs/api/server/hoodie.task.md
@@ -13,7 +13,7 @@ passed type, for example
 
 <pre>
     var taskStore = hoodie.store('task');
-    taskStore.findAll().then( showAllTasks );
+    taskStore.findAll().done( showAllTasks );
     taskStore.update('id123', {done: true});
 </pre>
 


### PR DESCRIPTION
> What you really have to recognized here is that there is a mayor difference between the methods `then` and `done`. While `done` suggests that you can handle all the retrieved objects with it, actually it is `then` where `findAll` will deliver your data to. `done` on the other hand gets called when all other `then` calls have been passed. Yes you can utilize this mechanism to work with your data in several steps.

There is more to `.then` than just being called before the .done callbacks. I see `.done` /  `.fail` / `.progress` as the public API that all users should use per default. `.then` is for advanced users that know what they are doing. And as they know that we return promises, they know it already.
