### PR TITLE
reworked hoodie.store.md

### DIFF
--- a/techdocs/api/client/hoodie.store.md
+++ b/techdocs/api/client/hoodie.store.md
@@ -35,6 +35,7 @@ different devices.
 - [store.updateAll()](#storeupdateall)
 - [store.remove()](#storeremove)
 - [store.removeAll()](#storeremoveall)
+- [store.on()](storeon)
 - [store()](#store)
 
 ## Events

--- a/techdocs/api/client/hoodie.store.md
+++ b/techdocs/api/client/hoodie.store.md
@@ -35,7 +35,6 @@ different devices.
 - [store.updateAll()](#storeupdateall)
 - [store.remove()](#storeremove)
 - [store.removeAll()](#storeremoveall)
-- [store.validate()](#storevalidate)
 - [store()](#store)
 
 ## Events

--- a/techdocs/api/client/hoodie.store.md
+++ b/techdocs/api/client/hoodie.store.md
@@ -16,12 +16,12 @@ update and remove objects. You can listen to object changes, e.g.
 to update your apps user interface. `hoodie.store` is user-specific,
 that means that a user can only access the objects of the current account.
 It works anonymously, too. Once signed up using the `hoodie.account` api,
-all data gets synchronized automatically, so it can be accessed from
+all objects get synchronized automatically, so it can be accessed from
 different devices.
 
 ###### Notes
 > - storing and accessing objects with hoodie always means accessing your personal, local objects.
-> - All stored data has a fixed association to the user who created them. So you won't be able to access other user's data by default.
+> - all stored objects have a fixed association to the user who created them. So you won't be able to access other user's objects by default.
 > - in order save objects to the server's store, you need to be logged in with a valid user. Learn more about the hoodie user system at [`hoodie.account`](./hoodie.account.md).
 
 
@@ -504,8 +504,7 @@ hoodie.store.on('config:app:remove', function(eventName, removedAppConfig) {});
 hoodie.store.on('clear', function(){});
 ```
 
-`clear` gets triggered when a user signed out, or called `hoodie.account.destroy()`. It gets also triggered when the user signs in, to clear up
-the local data before loading the data of the account the user signed into.
+`clear` gets triggered when a user signed out, or called `hoodie.account.destroy()`. It gets also triggered when the user signs in, to clear up the local objects before loading the objects of the account the user signed into.
 
 Note that no `remove` events get triggered when the store gets cleared,
 as the objects do not necessarly get removed for the user's account, but


### PR DESCRIPTION
Please consider all changes as suggestions only, I'm happy to revers or fix anything you're not happy with @snnd @zoepage. I must say that not only you did an amazing job, it really helped me to reflect on the API myself. Please get me in the loop whenever I can help with documentation, it's very helpful for me, too <3
- replaced 'data' with 'object(s)'
- moved scoped store api to the bottom
- removed scoped store from examples and just left hoodie.store.add etc
- changed type:add to just add
- added clear event
- added the options parameter to all methods, because I think that every
  method should be fully self-explanatory and not require to read another
  part of the documentation first
- Removed complex example that used  callback before
- findAll, updateAll, removeAll do not require a type right now, technically.
  But it's considered harmful as objects will be affected that might be used
  internally only, and therefore I'd rather say it is.
- I left out the validate method, as it's not really usable yet. But we
  will add it back in soon, esp. as option to the scoped store as sugested
  by Dennis (love the idea)
