### PR TITLE
adds missing hoodie methods to en/techdocs

### DIFF
--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -22,6 +22,7 @@ This document describes the functionality of the hoodie base object.
 - [off](#off)
 - [trigger](#trigger)
 - [request](#request)
+- [open](#open)
 - [extend](#extend)
 
 
@@ -218,6 +219,27 @@ hoodie.store(hoodie).trigger('trigger-test', 'number 3');
 .fail(handleError)
 </code></pre>
 
+
+<a id="open"></a>
+### open
+
+**version:**      *> 0.2.0*
+
+*Interact with a remote database*
+
+<pre><code>hoodie.open('db-name');</code></pre>
+
+| option     | type     | description            | required |
+| ---------- |:--------:|:----------------------:|:--------:|
+| name       | string   | name of the database   | yes      |
+
+
+##### Example
+<pre><code>var chat = hoodie.open('chatroom');
+chat.findAll('message')
+.done(renderMessages)
+.fail(handleError);
+</code></pre>
 
 
 <a id="extend"></a>

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -24,6 +24,7 @@ This document describes the functionality of the hoodie base object.
 - [request](#request)
 - [open](#open)
 - [checkConnection](#checkConnection)
+- [isConnected](#isConnected)
 - [extend](#extend)
 
 
@@ -256,6 +257,24 @@ chat.findAll('message')
 <pre><code>hoodie.checkConnection()
 .done(renderGreenLight)
 .fail(renderRedLight)
+</code></pre>
+
+
+<a id="isConnected"></a>
+### isConnected
+
+**version:**      *> 0.2.0*
+
+*Returns true if Hoodie backend can currently be reached, otherwise false*
+
+<pre><code>hoodie.isConnected();</code></pre>
+
+##### Example
+<pre><code>if (hoodie.isConnected()) {
+  alert('Looks like you are online!');
+} else {
+  alert('You are offline!');
+}
 </code></pre>
 
 

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -21,6 +21,7 @@ This document describes the functionality of the hoodie base object.
 - [one](#one)
 - [off](#off)
 - [trigger](#trigger)
+- [extend](#extend)
 
 
 <a id="baseUrl"></a>
@@ -191,4 +192,32 @@ todoStore.on('trigger-test', function(num) {
 hoodie.store.trigger('trigger-test', 'number 1');
 todoStore.trigger('trigger-test', 'number 2');
 hoodie.store(hoodie).trigger('trigger-test', 'number 3');
+</code></pre>
+
+
+
+<a id="extend"></a>
+### extend
+
+**version:**      *> 0.2.0*
+
+*Extend the hoodie API with new functionality*
+
+<pre><code>hoodie.extend(plugin);</code></pre>
+
+| option     | type     | description     | required |
+| ---------- |:--------:|:---------------:|:--------:|
+| plugin     | function | extend the frontend API with whatever logic your plugin wants to expose | yes |
+
+
+
+
+##### Example
+<pre><code>hoodie.extend(function(hoodie, lib, util) {
+  hoodie.sayHi = function() {
+    alert('say hi!');
+  };
+});
+
+hoodie.sayHi() // shows alert
 </code></pre>

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -21,6 +21,7 @@ This document describes the functionality of the hoodie base object.
 - [one](#one)
 - [off](#off)
 - [trigger](#trigger)
+- [request](#request)
 - [extend](#extend)
 
 
@@ -192,6 +193,29 @@ todoStore.on('trigger-test', function(num) {
 hoodie.store.trigger('trigger-test', 'number 1');
 todoStore.trigger('trigger-test', 'number 2');
 hoodie.store(hoodie).trigger('trigger-test', 'number 3');
+</code></pre>
+
+
+<a id="request"></a>
+### request
+
+**version:**      *> 0.2.0*
+
+*Send a request*
+
+<pre><code>hoodie.request(type, url, options);</code></pre>
+
+| option     | type     | description                                | required |
+| ---------- |:--------:|:------------------------------------------:|:--------:|
+| type       | string   | http verb, e.g. get, post, put or delete   | yes      |
+| url        | string   | relative path or absolute URL.             | yes      |
+| options    | object   | compare http://api.jquery.com/jquery.ajax/ | no       |
+
+
+##### Example
+<pre><code>hoodie.request('http://example.com/something')
+.done(renderSomething)
+.fail(handleError)
 </code></pre>
 
 

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -10,12 +10,35 @@ locales: en
 
 This document describes the functionality of the hoodie base object.
 
+### Properties
+
+- [baseUrl](#baseUrl)
+
 ## Methods
 
 - [on](#on)
 - [one](#one)
 - [off](#off)
 - [trigger](#trigger)
+
+
+<a id="baseUrl"></a>
+### hoodie.baseUrl
+**version:**    *> 0.2.0*
+
+<pre><code>hoodie.baseUrl</code></pre>
+
+The **hoodie.baseUrl** property gets automatically set on initialization.
+
+
+##### Example
+
+<pre><code>hoodie = new Hoodie('http://myhoodieapp.com')
+hoodie.baseUrl // 'http://myhoodieapp.com'
+
+hoodie = new Hoodie()
+hoodie.baseUrl // ''
+</code></pre>
 
 
 <a id="on"></a>

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -16,6 +16,7 @@ This document describes the functionality of the hoodie base object.
 
 ## Methods
 
+- [id](#id)
 - [on](#on)
 - [one](#one)
 - [off](#off)
@@ -38,6 +39,29 @@ hoodie.baseUrl // 'http://myhoodieapp.com'
 
 hoodie = new Hoodie()
 hoodie.baseUrl // ''
+</code></pre>
+
+
+<a id="id"></a>
+### id()
+**version:**      *> 0.2.0*
+
+*returns a unique, persistent identifier for the current user*
+
+<pre><code>hoodie.id();</code></pre>
+
+The first time <code>hoodie.id()</code> gets called, a unique
+identifier gets generated for the current user, and persisted
+in the browser's local store. When signing in to an account,
+<code>hoodie.id()</code> will return the id of the new user.
+On signout, hoodie.id() gets reset.
+
+##### Example
+<pre><code>
+hoodie.id(); // randomid123
+hoodie.account.signIn(username, password).done(function() {
+  hoodie.id(); // randomid456
+});
 </code></pre>
 
 

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -1,5 +1,5 @@
 ---
-layout: layout-api  
+layout: layout-api
 locales: en
 ---
 # hoodie
@@ -12,20 +12,19 @@ This document describes the functionality of the hoodie base object.
 
 ## Methods
 
-- [bind](#bind)
-- [trigger](#trigger)
-- [unbind](#unbind)
-- [one](#one)
 - [on](#on)
+- [one](#one)
 - [off](#off)
+- [trigger](#trigger)
 
-<a id="bind"></a>
-### bind()
+
+<a id="on"></a>
+### on()
 **version:**      *> 0.2.0*
 
 *Bind an event handler to a certain event so you get informed in case it gets triggered.*
 
-<pre><code>hoodie.bind('event', eventHandler); </code></pre>
+<pre><code>hoodie.on('event', eventHandler); </code></pre>
 
 | option     | type   | description     | required |
 | ---------- |:------:|:---------------:|:--------:|
@@ -36,9 +35,61 @@ Hoodie informs you about several things happening. For instance every time a sto
 
 ##### Example
 <pre><code>hoodie.store.on('event', function(createdTodo) {
-	console.log('A todo has been added => ', createdTodo);
+  console.log('A todo has been added => ', createdTodo);
 });
 </code></pre>
+
+
+<a id="one"></a>
+### one()
+**version:**      *> 0.2.0*
+
+*Is the one-time variant of [on](#on) and [off](#off). Once the event has been caught, it will be unbound automatically.*
+
+<pre><code>hoodie.one('event', eventHandler);</code></pre>
+
+| option       | type     | description                        | required |
+| ------------ |:--------:|:----------------------------------:|:--------:|
+| event        | String   | custom event identifier            | yes      |
+| eventHandler | Function | Function handling triggered event. | yes      |
+
+
+<a id="off"></a>
+### off()
+**version:**      *> 0.2.0*
+
+*Unbind all eventhandlers from a certain event. The events won't be triggered anymore.*
+
+<pre><code>hoodie.off('event');</code></pre>
+
+| option     | type   | description     | required |
+| ---------- |:------:|:---------------:|:--------:|
+| event      | String | custom event identifier. | yes |
+
+<pre><code>hoodie.on('event', eventHandler);</code></pre>
+
+While **hoodie.store.on** subscribes an handler function to a certain event **hoodie.store.off** does the opposite and will unsubscribe all previously registered handlers for the given event.
+
+##### Example
+
+<pre><code>var todoStore = hoodie.store('todo');
+todoStore.on('todo:done', function(doneTodo, t) {
+  // this will never be reached
+});
+
+todoStore.on('todo:done', function(doneTodo, t) {
+  // this will never be reached neither
+});
+
+// this unsubscribes both of the previously
+// subscribed event handlers
+todoStore.off('todo:done');
+
+todoStore.findAll().done(function(allTodos) {
+  todoStore.trigger('todo:done', allTodos[0], new Date());
+});
+</code></pre>
+
 
 <a id="trigger"></a>
 ### trigger
@@ -54,7 +105,7 @@ Hoodie informs you about several things happening. For instance every time a sto
 | event      | String | custom event identifier.                                 | yes |
 | param      | Object | Detail information the event will pass to the listeners. | no |
 
-Since you can listen for store events using [bind](#bind) or [on](#on), this gives you the opportunity to send events of your own to the listeners. This includes the standard events as mentionend in for instance [hoodie.store.on](/techdocs/api/client/hoodie.store.html#storeon) as well as your personal custom events. Imagine you want to trigger an event when a todo is done. This could look something similiar to this:
+Since you can listen for store events using [on](#on), this gives you the opportunity to send events of your own to the listeners. This includes the standard events as mentionend in for instance [hoodie.store.on](/techdocs/api/client/hoodie.store.html#storeon) as well as your personal custom events. Imagine you want to trigger an event when a todo is done. This could look something similiar to this:
 
 
 ##### Example
@@ -86,90 +137,11 @@ todoStore.findAll().done(function(allTodos) {
 <pre><code>var todoStore = hoodie.store('todo');
 
 todoStore.on('trigger-test', function(num) {
-	// will only be called by the second trigger
-	console.log('triggered by', num);
+  // will only be called by the second trigger
+  console.log('triggered by', num);
 });
 
 hoodie.store.trigger('trigger-test', 'number 1');
 todoStore.trigger('trigger-test', 'number 2');
 hoodie.store(hoodie).trigger('trigger-test', 'number 3');
 </code></pre>
-
-<a id="unbind"></a>
-### unbind()
-**version:**      *> 0.2.0*
-
-*Unbind all eventhandlers from a certain event. The events won't be triggered anymore.*
-
-<pre><code>hoodie.unbind('event');</code></pre>
-
-| option     | type   | description     | required |
-| ---------- |:------:|:---------------:|:--------:|
-| event      | String | custom event identifier. | yes |
-
-<pre><code>hoodie.on('event', eventHandler);</code></pre>
-
-While **hoodie.store.bind** subscribes an handler function to a certain event **hoodie.store.unbind** does the opposite and will unsubscribe all previously registered handlers for the given event.
-
-##### Example
-
-<pre><code>var todoStore = hoodie.store('todo');
-todoStore.on('todo:done', function(doneTodo, t) {
-  // this will never be reached
-});
-
-todoStore.on('todo:done', function(doneTodo, t) {
-  // this will never be reached neither
-});
-
-// this unsubscribes both of the previously
-// subscribed event handlers
-todoStore.off('todo:done');
-
-todoStore.findAll().done(function(allTodos) {
-  todoStore.trigger('todo:done', allTodos[0], new Date());
-});
-</code></pre>
-
-<a id="one"></a>
-### one()
-**version:**      *> 0.2.0*
-
-*Is the one-time variant of [bind](#bind) plus [unbind](#unbind). Once the event has been caught, it will be unbound automatically.*
-
-<pre><code>hoodie.one('event', eventHandler);</code></pre>
-
-| option     | type   | description     | required |
-| ---------- |:------:|:---------------:|:--------:|
-| event        | String   | custom event identifier            | yes |
-| eventHandler | Function | Function handling triggered event. | yes |
-
-
-<a id="on"></a>
-### on()
-**version:**      *> 0.2.0*
-
-*Bind an event handler to a certain event so you get informed in case it gets triggered.*
-
-<pre><code>hoodie.on('event', eventHandler);</code></pre>
-
-| option     | type   | description     | required |
-| ---------- |:------:|:---------------:|:--------:|
-| event        | String   | custom event identifier            | yes |
-| eventHandler | Function | Function handling triggered event. | yes |
-
-Alias for [bind](#bind).
-
-<a id="off"></a>
-### off()
-**version:**      *> 0.2.0*
-
-*Unbind all eventhandlers from a certain event. The events won't be triggered anymore.*
-
-<pre><code>hoodie.off('event');</code></pre>
-
-| option     | type   | description     | required |
-| ---------- |:------:|:---------------:|:--------:|
-| event        | String   | custom event identifier            | yes |
-
-Alias for [unbind](#unbind).

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -23,6 +23,7 @@ This document describes the functionality of the hoodie base object.
 - [trigger](#trigger)
 - [request](#request)
 - [open](#open)
+- [checkConnection](#checkConnection)
 - [extend](#extend)
 
 
@@ -239,6 +240,22 @@ hoodie.store(hoodie).trigger('trigger-test', 'number 3');
 chat.findAll('message')
 .done(renderMessages)
 .fail(handleError);
+</code></pre>
+
+
+<a id="checkConnection"></a>
+### checkConnection
+
+**version:**      *> 0.2.0*
+
+*Sends request to the Hoodie Server to check if it is reachable*
+
+<pre><code>hoodie.checkConnection();</code></pre>
+
+##### Example
+<pre><code>hoodie.checkConnection()
+.done(renderGreenLight)
+.fail(renderRedLight)
 </code></pre>
 
 

--- a/en/techdocs/api/client/hoodie.md
+++ b/en/techdocs/api/client/hoodie.md
@@ -51,21 +51,21 @@ hoodie.baseUrl // ''
 ### id()
 **version:**      *> 0.2.0*
 
-*returns a unique, persistent identifier for the current user*
+*Returns a unique, persistent identifier for the current user.*
 
 <pre><code>hoodie.id();</code></pre>
 
-The first time <code>hoodie.id()</code> gets called, a unique
+The first time **hoodie.id()** gets called, a unique
 identifier gets generated for the current user, and persisted
 in the browser's local store. When signing in to an account,
-<code>hoodie.id()</code> will return the id of the new user.
+**hoodie.id()** will return the id of the new user.
 On signout, hoodie.id() gets reset.
 
 ##### Example
-<pre><code>
-hoodie.id(); // randomid123
-hoodie.account.signIn(username, password).done(function() {
-  hoodie.id(); // randomid456
+<pre><code>hoodie.id(); // randomid123
+hoodie.account.signIn(username, password)
+  .done(function() {
+    hoodie.id(); // randomid456
 });
 </code></pre>
 
@@ -217,8 +217,8 @@ hoodie.store(hoodie).trigger('trigger-test', 'number 3');
 
 ##### Example
 <pre><code>hoodie.request('http://example.com/something')
-.done(renderSomething)
-.fail(handleError)
+  .done(renderSomething)
+  .fail(handleError);
 </code></pre>
 
 
@@ -239,8 +239,8 @@ hoodie.store(hoodie).trigger('trigger-test', 'number 3');
 ##### Example
 <pre><code>var chat = hoodie.open('chatroom');
 chat.findAll('message')
-.done(renderMessages)
-.fail(handleError);
+  .done(renderMessages)
+  .fail(handleError);
 </code></pre>
 
 
@@ -255,8 +255,8 @@ chat.findAll('message')
 
 ##### Example
 <pre><code>hoodie.checkConnection()
-.done(renderGreenLight)
-.fail(renderRedLight)
+  .done(renderGreenLight)
+  .fail(renderRedLight);
 </code></pre>
 
 
@@ -293,7 +293,6 @@ chat.findAll('message')
 
 
 
-
 ##### Example
 <pre><code>hoodie.extend(function(hoodie, lib, util) {
   hoodie.sayHi = function() {
@@ -301,5 +300,5 @@ chat.findAll('message')
   };
 });
 
-hoodie.sayHi() // shows alert
+hoodie.sayHi(); // shows alert
 </code></pre>


### PR DESCRIPTION
fixes #13 

Adds techdocs for 
- hoodie.isConnected()
- hoodie.checkConnection()
- hoodie.open(db-name)
- hoodie.request(type, url, options)
- hoodie.extend(plugin)
- hoodie.id()
- hoodie.baseUrl

@zoepage There are some design-foo in there, could you please double check? I've used `<code>` to highlight code in text, but it seems to be styled as block, for example in the `hoodie.id()` description.
