### PR TITLE
Link is in German

### DIFF
--- a/en/deployment/index.md
+++ b/en/deployment/index.md
@@ -13,4 +13,4 @@ Here is a great tutorial on how to <a href="../deployment/linux.html">deploy you
 <a href="https://appback.com/">Hoodie at Appback</a>
 
 #### For Developers
-<a href="https://wiki.uberspace.de/cool:hoodie">Hoodie at Uberspace</a>
+<a href="https://wiki.uberspace.de/cool:hoodie">Hoodie at Uberspace (page in German)</a>


### PR DESCRIPTION
It surprised me when I clicked it from the English docs.

Opening as PR because we might want to remove the link entirely from the English docs?
