### PR TITLE
updates hoodie.store api doc to include store.updateOrAdd

### DIFF
--- a/en/techdocs/api/client/hoodie.store.md
+++ b/en/techdocs/api/client/hoodie.store.md
@@ -36,6 +36,7 @@ different devices.
 - [store.findOrAdd()](#storefindoradd)
 - [store.findAll()](#storefindall)
 - [store.update()](#storeupdate)
+- [store.updateOrAdd()](#storeupdateoradd)
 - [store.updateAll()](#storeupdateall)
 - [store.remove()](#storeremove)
 - [store.removeAll()](#storeremoveall)
@@ -234,6 +235,35 @@ hoodie.store.update('todo', 'abc4567', function(oneTodo) {
   .fail(function(error) {})
 </code></pre>
 
+<a id="storeupdateoradd"></a>
+### store.updateOrAdd()
+**version:**      *> 0.2.0*
+
+Changes the passed attributes of an existing object, if it exists; otherwise, creates a new objects in your local store.
+
+<pre><code>hoodie.store.updateOrAdd(type, id, updateObject);</code></pre>
+
+| option     | type   | description     | required |
+| ---------- |:------:|:---------------:|:--------:|
+| type           | String | type of the store                   | yes |
+| id         | String | id of the object to find                    | yes  |
+| updateObject     | Object | new object values                   | yes  |
+| options.silent | Boolean  | If set to **true**, no events will be triggered from this call | no (default: false) |
+
+Returns a promise. If succesful, it calls the **done** callback with the updated or new object stored with updated or new properties 
+added to it (id, createdBy, createdAt, updatedAt). If something
+goes wrong, the **fail** callback will be called instead and an error gets passed.
+
+##### Example
+
+<pre><code>hoodie.store.updateOrAdd('todo', 13, {title: 'New, Better Title'} )
+  .done(function(updates) {
+  	console.log('the following todos are done', updates);
+  })
+  .fail(function(error) {
+        console.log('An error happened while updating or adding a todo', error);
+  });</code></pre>
+
 <a id="storeupdateall"></a>
 ### store.updateAll()
 **version:**      *> 0.2.0*
@@ -259,7 +289,6 @@ callback gets called instead. </small>
   .done(function(updates) {
   	console.log('the following todos are done', updates);
   });</code></pre>
-
 
 <a id="storeremove"></a>
 ### store.remove()

--- a/en/techdocs/api/client/hoodie.store.md
+++ b/en/techdocs/api/client/hoodie.store.md
@@ -256,7 +256,7 @@ goes wrong, the **fail** callback will be called instead and an error gets passe
 
 ##### Example
 
-<pre><code>hoodie.store.updateOrAdd('todo', 13, {title: 'New, Better Title'} )
+<pre><code>hoodie.store.updateOrAdd('todo', abc456, {title: 'New, Better Title'} )
   .done(function(updates) {
   	console.log('the following todos are done', updates);
   })


### PR DESCRIPTION
Fixes: https://github.com/hoodiehq/documentation/issues/121

After reading through hoodie.js and testing the function in a Hoodie test app, I'm fairly confident in this addition to the documentation. The only thing I am unsure of is the requirement of an 'id' as an argument. In the documentation for store.update(), an 'id' argument is passed in but it is not described argument table. 

![hoodie.store.update() docs](https://cloud.githubusercontent.com/assets/3051193/7056294/8f9cf664-de18-11e4-81bc-848d3fc1765e.png)

Interested in your feedback. I definitely want to make sure it is understandable for everyone. :+1: 
