### PR TITLE
(todo app) fix broken sort after changing model

### DIFF
--- a/en/tutorials/index.md
+++ b/en/tutorials/index.md
@@ -161,6 +161,8 @@ to ...
 
 At this point you should start seeing that each task listed is prefaced by a priority. Hoodie makes it pretty easy to add new fields to a store.
 
+If you haven't ticked of all old tasks ("old" meaning tasks which were created before we added the priority menu), those will now render "undefinded" in place of a priority. Now is a good time to tick off thoses old tasks until only tasks with a priority remain.
+
 
 ### 9. Sort By Priority
 


### PR DESCRIPTION
- sort function broke when sorting by priority and tasks with priority "undefinded" were still in the list
- add hint to remove tasks without priority
