### PR TITLE
fix(chatapp): add alt tags to user avatars (a11y)

### DIFF
--- a/en/tutorials/chat-app.md
+++ b/en/tutorials/chat-app.md
@@ -42,7 +42,7 @@ Let's make some edits to our **index.html** file to fit our app's structural nee
   <div class="user-avatar relative">
 
     <!-- default the img src to a placekitten url for a little extra fun  and don't forget the extra style classes-->
-    <img src="http://placekitten.com/g/50/50" data-avatar="currentUser" width="50px" height="50px" class="mr1 rounded relative" />
+    <img src="http://placekitten.com/g/50/50" data-avatar="currentUser" width="50px" height="50px" class="mr1 rounded relative" alt="your avatar"/>
 
   </div>
 
@@ -230,7 +230,7 @@ function streamMessage(message) {
   
   // create template to store message content
   var messageTemplate = $('<div class="p1 '+bgColor+' flex flex-stretch"></div>');
-  var messageAvatar = $('<aside class="flex flex-stretch rounded overflow-hidden mr2"><img src="http://placekitten.com/g/50/50" width="50px" height="50px" data-avatar="'+message.user+'" /></aside>');
+  var messageAvatar = $('<aside class="flex flex-stretch rounded overflow-hidden mr2"><img src="http://placekitten.com/g/50/50" width="50px" height="50px" data-avatar="'+message.user+'" alt="'+message.user+'\'s avatar"/></aside>');
   var messageContentContainer = $('<div></div>');
   var messageUser = $('<h4 class="inline-block mt0 mr1">'+message.user+'</h4>');
   var messageDate = $('<span class="inline-block h6 regular muted">'+date.toLocaleTimeString()+'</span>');


### PR DESCRIPTION
This PR adds alt tags to all user avatar images.
Please only merge this if you have merged the accompanying change to the hoodie-chat-app-template: https://github.com/hoodiehq/hoodie-template-app-chat/pull/9
