### PR TITLE
Fix path to hoodie-css framework JS

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -193,7 +193,7 @@
                 </section>
             </div>
         </footer>
-        <script src="http://hood.ie/dist/prod/hoodie.min.js"></script>
+        <script src="//hoodiehq.github.io/hoodie-css/src/js/prod/hoodie.min.js"></script>
         <script type="text/javascript" src="/src/js/smoothscroll.min.js"></script>
         <script src="/src/js/egg.js"></script>
         <script src="/src/js/prism.js"></script>


### PR DESCRIPTION
The path to the hoodie-css framework JS was broken, so I changed it to the correct URL. Simple, but effective! :boom: 
