### PR TITLE
Show docs sub-nav on mobile (Fixes GH-185)

### DIFF
--- a/src/stylesheets/docs.css
+++ b/src/stylesheets/docs.css
@@ -275,3 +275,13 @@ header.invisible{
   -ms-transform: translate(0, -102px);
   transform: translate(0, -102px);
 }
+
+/* shows sub-nav on mobile */
+/* TODO: find better place for this */
+.mobile header, .mobile header.detached {
+  height: 125px;
+}
+
+.mobile .sub-nav {
+  display: block;
+}


### PR DESCRIPTION
![screen shot 2015-11-17 at 10 20 55 pm](https://cloud.githubusercontent.com/assets/1459603/11234099/9092c3b2-8d79-11e5-9c10-95a61b4e92db.png)

This is just a bit of CSS to show the `.sub-nav` class on mobile. I'm totally open to suggestions for a better place to put the code, since it might actually be useful to have this change elsewhere as well. In any case, this is at least a PR to start the conversation. :smile: 
