### PR TITLE
improved grammar, expression

### DIFF
--- a/en/techdocs/api/client/hoodie.account.md
+++ b/en/techdocs/api/client/hoodie.account.md
@@ -310,13 +310,13 @@ hoodie.account.resetPassword(username);
 
 | Nr | option     | type   | description                    | required |
 |:--:|:---------- |:------ |:------------------------------ |:-------- |
-|  1 | username   | String | username to reset password for | yes      |
+|  1 | username   | String | username for which to reset password | yes      |
 
 ##### Resolves with
 
 | argument    | description                                          |
 | ----------- | ---------------------------------------------------- |
-| username    | the username that got the password resetted          |
+| username    | the username whose password was reset          |
 
 ##### Rejects with
 


### PR DESCRIPTION
It's arguably better not to end a sentence with the preposition "for," even if the old rule "Never end a sentence with a preposition" isn't always true.

"Resetted" is not a word in English, so far as I know.  "Reset" is the past passive indicative form which should be used here.
