### PR TITLE
Revert github-pages to v71 until Jekyll is fixed.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins
+gem 'github-pages', '71', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,14 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     gemoji (2.1.0)
-    github-pages (75)
+    github-pages (71)
       RedCloth (= 4.2.9)
       github-pages-health-check (= 1.1.0)
-      jekyll (= 3.0.4)
+      jekyll (= 3.0.3)
       jekyll-coffeescript (= 1.0.1)
       jekyll-feed (= 0.5.1)
       jekyll-gist (= 1.4.0)
-      jekyll-github-metadata (= 1.11.1)
+      jekyll-github-metadata (= 1.11.0)
       jekyll-mentions (= 1.1.2)
       jekyll-paginate (= 1.1.0)
       jekyll-redirect-from (= 0.10.0)
@@ -39,7 +39,6 @@ GEM
       jemoji (= 0.6.2)
       kramdown (= 1.10.0)
       liquid (= 3.0.6)
-      listen (= 3.0.6)
       mercenary (~> 0.3)
       rdiscount (= 2.1.8)
       redcarpet (= 3.3.3)
@@ -55,7 +54,7 @@ GEM
       activesupport (>= 2, < 5)
       nokogiri (>= 1.4)
     i18n (0.7.0)
-    jekyll (3.0.4)
+    jekyll (3.0.3)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -69,7 +68,7 @@ GEM
     jekyll-feed (0.5.1)
     jekyll-gist (1.4.0)
       octokit (~> 4.2)
-    jekyll-github-metadata (1.11.1)
+    jekyll-github-metadata (1.11.0)
       octokit (~> 4.0)
     jekyll-mentions (1.1.2)
       html-pipeline (~> 2.3)
@@ -93,7 +92,7 @@ GEM
     json (1.8.3)
     kramdown (1.10.0)
     liquid (3.0.6)
-    listen (3.0.6)
+    listen (3.1.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
@@ -128,7 +127,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages
+  github-pages (= 71)
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
Using the github pages gem before the "backwards compatibilize" fixes
were made is necessary to prevent --watch from breaking.

The site will still be built with version 75 once pushed to Github.  The version constraint should be removed once https://github.com/jekyll/jekyll/issues/4831 is closed and a new release is tagged.

Once you pull this change run `bundle install` and then `bundle exec jekyll serve` to test.

Closes #211
