### PR TITLE
Switch markdown to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
-markdown: redcarpet
-redcarpet:
-  extensions: ["tables"]
+markdown: kramdown
+kramdown:
+    auto_ids: false
 
 locales:
   en:


### PR DESCRIPTION
kramdown is the default for Jekyll 3 and required for building
with github-pages by May 1st, 2016.

see https://help.github.com/articles/updating-your-markdown-processor-to-kramdown/

The auto_ids config was copied from hoodiehq/hood.ie, and is explained [here](http://kramdown.gettalong.org/converter/html.html).

> If this option is true, ID values for all headers are automatically generated if no ID is explicitly specified.

I checked the tables and they appear to render correctly.

![hoodie-table](https://cloud.githubusercontent.com/assets/9440455/14788474/fc79ec5c-0ad5-11e6-8f1f-6bc7c6a5cc16.png)

Everything looks correct to me, but I would definitely take a look before merging.  Thanks!

Closes #210
