### PR TITLE
Disable rouge syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,8 @@
 markdown: kramdown
 kramdown:
     auto_ids: false
+    syntax_highlighter_opts:
+      disable : true
 
 locales:
   en:


### PR DESCRIPTION
Disable rouge syntax highlighting since we use prism.js and rouge
is adding conflicting css.  The normal option `highlighter: false` doesn't work with the github-pages gem as explained [here](https://github.com/github/pages-gem/issues/198).

Here are before and after screenshots:

![with-rouge](https://cloud.githubusercontent.com/assets/9440455/14789012/87ac72ca-0ad8-11e6-9849-ebc78d2c4454.png)
![without-rouge](https://cloud.githubusercontent.com/assets/9440455/14789014/89768550-0ad8-11e6-9629-d83075f05a4a.png)
