### PR TITLE
Correct spelling of Doccker to Docker

### DIFF
--- a/camp/deployment/linux.md
+++ b/camp/deployment/linux.md
@@ -6,4 +6,4 @@ locales: camp
 # Hoodie Deployment Guide
 
 This document needs an update. See the [outdated version](/en/deployment/linux.html)
-and check out how we [deploy our demo application using Doccker & Digital Ocean](https://github.com/hoodiehq/hoodie-app-tracker/blob/master/deployment.md)
+and check out how we [deploy our demo application using Docker & Digital Ocean](https://github.com/hoodiehq/hoodie-app-tracker/blob/master/deployment.md)


### PR DESCRIPTION
Just something I noticed while browsing.
