### PR TITLE
Link to  camp start page

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -39,4 +39,4 @@ You [could read up on some of the ideological concepts behind Hoodie](/en/hoodie
 
 If you're more interested in the technical details of Hoodie, check out [How Hoodie Works](/en/hoodieverse/how-hoodie-works.html). Learn how Hoodie handles data storage, does syncing, and where the offline support comes from.
 
-Eager to build stuff? Skip ahead to the [installation guide](/en/start/)!
+Eager to build stuff? Skip ahead to the [installation guide](.../start/)!


### PR DESCRIPTION
Not sure if I understand the link system, but the current english camp index docs page links to he old installation page. 
http://docs.hood.ie/camp/
Links to 
http://docs.hood.ie/en/start/
Instead of:
http://docs.hood.ie/camp/start/

I hope this change fixes that?
