### PR TITLE
docs(getting-started-1): fixed typo

### DIFF
--- a/camp/start/getting-started/getting-started-1.md
+++ b/camp/start/getting-started/getting-started-1.md
@@ -89,7 +89,7 @@ mkdir public
 touch public/index.html
 ```
 
-Now edit the **public/index.html** file and past in the following content.
+Now edit the **public/index.html** file and pass in the following content.
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Minor typo fix -- changed 'past' to 'pass'.
