### PR TITLE
Update getting started instructions

### DIFF
--- a/camp/start/getting-started/getting-started-1.md
+++ b/camp/start/getting-started/getting-started-1.md
@@ -120,13 +120,13 @@ Open your browser’s console (command + alt + j on Mac, ctrl + alt + j on Windo
 This is how Hoodie apps talk to their servers. For example, type in
 
 ```js
-hoodie.account.signUp({username: 'Robin', password: 'secret'})
+hoodie.account.signUp({username: 'robin', password: 'secret'})
 ```
 
 Congratulations, you just created a user account :) You can now sign in to it using
 
 ```js
-hoodie.account.signIn({username: 'Robin', password: 'secret'})
+hoodie.account.signIn({username: 'robin', password: 'secret'})
 ```
 
 Okay we got ahead of ourselves, the short version is: all assets like html, JavaScript or CSS files in the public folder will be served by the Hoodie Server at the **/** root path.


### PR DESCRIPTION
As there is a unfixed bug hoodiehq/hoodie#614 and hoodiehq/hoodie-account-client#115 relating to capitalized names used in `hoodie.account.signUp`, I propose to use lower-case name in the **getting started guide** until the bug is fixed, so people trying out hoodie won't get thrown off. I was.
