### PR TITLE
update on the glossary page

### DIFF
--- a/camp/hoodieverse/glossary.md
+++ b/camp/hoodieverse/glossary.md
@@ -5,9 +5,13 @@ locales: camp
 
 # Glossary of Terms
 
-## CouchDB/PouchDB
+## CouchDB
 
-[CouchDB](http://couchdb.apache.org/) is a non-relational, document-based database that replicates, which means it's really good at syncing data between multiple instances of itself. All data is stored as JSON, all indices (queries) are written in JavaScript, and it uses regular HTTP as its API. It gets along wonderfully with [PouchDB](http://pouchdb.com/), the in-browser version of CouchDB, which Hoodie is currently migrating to for storing data locally, in browser.
+[CouchDB](http://couchdb.apache.org/) is a non-relational, document-based database that replicates, which means it's really good at syncing data between multiple instances of itself. All data is stored as JSON, all indices (queries) are written in JavaScript, and it uses regular HTTP as its API.
+
+## PouchDB
+
+[PouchDB](http://pouchdb.com/) is an in-browser datastore inspired by CouchDB. It enables applications to store data locally while offline, then synchronize it with CouchDB.
 
 ## Users
 

--- a/camp/hoodieverse/glossary.md
+++ b/camp/hoodieverse/glossary.md
@@ -5,19 +5,14 @@ locales: camp
 
 # Glossary of Terms
 
-### CouchDB/PouchDB
+## CouchDB/PouchDB
+
 [CouchDB](http://couchdb.apache.org/) is a non-relational, document-based database that replicates, which means it's really good at syncing data between multiple instances of itself. All data is stored as JSON, all indices (queries) are written in JavaScript, and it uses regular HTTP as its API. It gets along wonderfully with [PouchDB](http://pouchdb.com/), the in-browser version of CouchDB, which Hoodie is currently migrating to for storing data locally, in browser.
 
-### Users
+## Users
+
 Hoodie isn't a CMS, but a backend for web apps, and as such, it is very much centered around users. All of the offline and sync features are specific to each individual user's data, and each user's data is encapsulated from that of all others by default. This allows Hoodie to easily know what to sync between a user's clients and the server: simply all of the user's private data.
 
-### Private User Store
+## Private User Store
+
 Every user signed up with your Hoodie app has their own little database, which is private by default. Anything you do in the **hoodie.store** methods stores data in here.
-
----
-
-TODO:
-
-- Client
-- Server
-- Plugins

--- a/camp/hoodieverse/glossary.md
+++ b/camp/hoodieverse/glossary.md
@@ -13,6 +13,10 @@ locales: camp
 
 [PouchDB](http://pouchdb.com/) is an in-browser datastore inspired by CouchDB. It enables applications to store data locally while offline, then synchronize it with CouchDB.
 
+## hapi
+
+[hapi](http://hapijs.com/) is a rich framework for building applications and services, enabling developers to focus on writing reusable application logic and not waste time with infrastructure logic. You can [load hoodie as a hapi plugin](https://github.com/hoodiehq/hoodie#hapi-plugin) to use it in your existing hapi application.
+
 ## Users
 
 Hoodie isn't a CMS, but a backend for web apps, and as such, it is very much centered around users. All of the offline and sync features are specific to each individual user's data, and each user's data is encapsulated from that of all others by default. This allows Hoodie to easily know what to sync between a user's clients and the server: simply all of the user's private data.


### PR DESCRIPTION
part of #230

- removed the interruptive TODO section
- separated couchdb and pouchdb definitions
- added secction for hapi